### PR TITLE
Graceful error handling for Kickflip

### DIFF
--- a/sdk/src/main/java/io/kickflip/sdk/KickflipApplication.java
+++ b/sdk/src/main/java/io/kickflip/sdk/KickflipApplication.java
@@ -6,14 +6,23 @@ public class KickflipApplication {
 
     private static boolean initialized = false;
     private static Context mContext;
+    private static KickflipEventListener sKickflipEventListener;
 
     public static Context instance() {
         return mContext;
+    }
+
+    public static KickflipEventListener getKickflipEventListener() {
+        return sKickflipEventListener;
     }
 
     public static void init(Context context) {
         if (initialized) return;
         initialized = true;
         mContext = context;
+    }
+
+    public static void setKickflipEventListener(KickflipEventListener kickflipEventListener) {
+        sKickflipEventListener = kickflipEventListener;
     }
 }

--- a/sdk/src/main/java/io/kickflip/sdk/KickflipEventListener.java
+++ b/sdk/src/main/java/io/kickflip/sdk/KickflipEventListener.java
@@ -1,0 +1,7 @@
+package io.kickflip.sdk;
+
+public interface KickflipEventListener {
+
+    public void onKickflipError(Exception e);
+
+}


### PR DESCRIPTION
## Added an error listener for Kickflip

Since many devices seem to be having issues with the `CameraEncoder` class, exceptions are now reported with a callback instead of throwing an exception so that they can be handled gracefully.